### PR TITLE
CDC-CC-31900-GetSections creates messages from text files

### DIFF
--- a/ProjectSource/src/test/java/com/kayako/sdk/mockserver/helpcenter/responses/GetSections.java
+++ b/ProjectSource/src/test/java/com/kayako/sdk/mockserver/helpcenter/responses/GetSections.java
@@ -5,9 +5,17 @@ import com.kayako.sdk.utils.MessageLoader;
 
 public class GetSections extends SampleResponse {
 
+  private static final String METHOD = "GET";
+  private static final String REQUEST_URL =
+      "http://support.kayako.com//api/v1/sections.json?_case=camel&include=localeField,category&limit=10&category_id=1&offset=0";
+  private static final int STATUS_CODE = 200;
+
+  private static final String MESSAGE_FILE = "sections";
+  private static final String CONTENTS_FILE = "section";
+  private static final int CONTENTS_LENGTH = 10;
+
   public GetSections() {
-    super("GET",
-        "http://support.kayako.com//api/v1/sections.json?_case=camel&include=localeField,category&limit=10&category_id=1&offset=0",
-        200, MessageLoader.readFile("sections", "section", 10));
+    super(METHOD, REQUEST_URL, STATUS_CODE,
+        MessageLoader.readFile(MESSAGE_FILE, CONTENTS_FILE, CONTENTS_LENGTH));
   }
 }


### PR DESCRIPTION
CDC-CC-31900:
Jira Ticket Link: https://jira.devfactory.com/browse/CC-31900
In order to avoid generating a long message containing a json response from code, the data is now obtained from files:
- resources/mockedMessages/message_sections.txt
- resources/mockedMessages/section_1.txt
- resources/mockedMessages/section_2.txt
- resources/mockedMessages/section_3.txt
- resources/mockedMessages/section_4.txt
- resources/mockedMessages/section_5.txt
- resources/mockedMessages/section_6.txt
- resources/mockedMessages/section_7.txt
- resources/mockedMessages/section_8.txt
- resources/mockedMessages/section_9.txt
- resources/mockedMessages/section_10.txt
